### PR TITLE
修复zdbk和eta的https传输协议更新

### DIFF
--- a/src-tauri/src/account.rs
+++ b/src-tauri/src/account.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tauri::{AppHandle, Emitter};
 use tokio::sync::Mutex;
-const ZDBK_URL :&str="https://zjuam.zju.edu.cn/cas/login?service=http://zdbk.zju.edu.cn/jwglxt/xtgl/login_ssologin.html";
-pub const ETA_URL: &str = "http://eta.zju.edu.cn/index/student";
+const ZDBK_URL :&str="https://zjuam.zju.edu.cn/cas/login?service=https://zdbk.zju.edu.cn/jwglxt/xtgl/login_ssologin.html";
+pub const ETA_URL: &str = "https://eta.zju.edu.cn/index/student";
 lazy_static! {
     // 用Mutex包装，这样可以获取可变引用进行修改
     pub static ref ACCOUNT: Mutex<Account> = Mutex::new(Account::load());

--- a/src-tauri/src/grade.rs
+++ b/src-tauri/src/grade.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use tokio::sync::Mutex;
 use tauri::{AppHandle, Emitter};
-const ETA_GRADE_URL: &str = "http://eta.zju.edu.cn/zftal-xgxt-web/api/teacher/xshx/getKccjList.zf";
+const ETA_GRADE_URL: &str = "https://eta.zju.edu.cn/zftal-xgxt-web/api/teacher/xshx/getKccjList.zf";
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Grade {
     pub name: String,

--- a/src-tauri/src/test.rs
+++ b/src-tauri/src/test.rs
@@ -19,7 +19,7 @@ pub struct Test {
 impl Session {
     pub async fn get_tests(&self) -> Result<Vec<Test>> {
         let id = ACCOUNT.lock().await.stuid.clone();
-        let url = format!("http://zdbk.zju.edu.cn/jwglxt/xskscx/kscx_cxXsgrksIndex.html?doType=query&gnmkdm=N509070&layout=default&su={id}#");
+        let url = format!("https://zdbk.zju.edu.cn/jwglxt/xskscx/kscx_cxXsgrksIndex.html?doType=query&gnmkdm=N509070&layout=default&su={id}#");
         let form = json!(
             {
                 "_search": false,


### PR DESCRIPTION
原有http协议更新至https后部分功能不可用，现修复